### PR TITLE
Support replies and reposts to silos

### DIFF
--- a/inc/content.php
+++ b/inc/content.php
@@ -108,6 +108,16 @@ function reply_or_repost($properties, $content) {
             } else {
                 # no silo specific function is registered for this one.
                 # do something generic.
+                if ($type == 'in-reply-to') {
+                    $prefix = '<div class="u-in-reply-to">Replying to ';
+                    $suffix = '<div class="e-content">' . $content . '</div>';
+                }
+                if ($type == 'repost-of') {
+                    $prefix = '<div class="u-repost-of">Repost of ';
+                    $suffix = '';
+                }
+                $markup = '<a class="u-url" href="' . $properties[$type] . '">' . $properties[$type] . '</a></div>';
+                $content = $prefix . $markup . $suffix;
             }
         }
     }

--- a/inc/content.php
+++ b/inc/content.php
@@ -103,8 +103,8 @@ function reply_or_repost($properties, $content) {
             # all dots to underscores.
             $target = str_replace('.', '_', parse_url($properties[$type], PHP_URL_HOST));
             # if a function exists for this type + target combo, call it
-            if function_exists("$target_$t") {
-                list($properties, $content) = call_user_func("$target_$t", $properties, $content);
+            if function_exists("${target}_${t}") {
+                list($properties, $content) = call_user_func("${target}_${t}", $properties, $content);
             } else {
                 # no silo specific function is registered for this one.
                 # do something generic.

--- a/inc/content.php
+++ b/inc/content.php
@@ -103,7 +103,7 @@ function reply_or_repost($properties, $content) {
             # all dots to underscores.
             $target = str_replace('.', '_', parse_url($properties[$type], PHP_URL_HOST));
             # if a function exists for this type + target combo, call it
-            if function_exists("${target}_${t}") {
+            if (function_exists("${target}_${t}")) {
                 list($properties, $content) = call_user_func("${target}_${t}", $properties, $content);
             } else {
                 # no silo specific function is registered for this one.

--- a/inc/content.php
+++ b/inc/content.php
@@ -109,7 +109,7 @@ function reply_or_repost($properties, $content) {
                 # no silo specific function is registered for this one.
                 # do something generic.
                 if ($type == 'in-reply-to') {
-                    $prefix = '<div class="u-in-reply-to">Replying to ';
+                    $prefix = '<div class="u-in-reply-to">In reply to ';
                     $suffix = '<div class="e-content">' . $content . '</div>';
                 }
                 if ($type == 'repost-of') {

--- a/inc/twitter.php
+++ b/inc/twitter.php
@@ -9,6 +9,59 @@ function get_tweet_id($url = '') {
     return trim(substr($url, strrpos($url, '/')), '/');
 }
 
+# Tweets are fully quotable in reply or repost context, so these are
+# all just wrappers around a single function that handles both cases.
+function twitter_com_in_reply_to($properties, $content) {
+    return twitter_reply_or_repost('in-reply-to', $properties, $content);
+}
+function twitter_com_repost_of($properties, $content) {
+    return twitter_reply_or_repost('repost-of', $properties, $content);
+}
+function m_twitter_com_in_reply_to($properties, $content) {
+    return twitter_reply_or_repost('in-reply-to', $properties, $content);
+}
+function m_twitter_com_repost_of($properties, $content) {
+    return twitter_reply_or_repost('repost-of', $properties, $content);
+}
+
+# replies and reposts have very similar markup, so this builds it.
+function twitter_reply_or_repost( $type, $properties, $content) {
+    global $config;
+    if (!isset($config['syndication']['twitter'])) {
+        return [$properties, $content];
+    }
+    $properties['posttype'] = $type;
+
+    # we'll use this when building a reply.
+    $suffix = '<div class="e-content">' . $content . '</div>';
+
+    $tweet = get_tweet($config['syndication']['twitter'], $properties[$type]);
+    if ( false !== $tweet ) {
+        $properties["$type-name"] = $tweet->user->name;
+        if ($type == 'in-reply-to') {
+            $prefix = '<div class="u-in-reply-to h-cite">Replying to ';
+        }
+        if ($type == 'repost-of') {
+            $prefix = '<div class="u-repost-of h-cite">Repost of ';
+            $suffix = '';
+        }
+        $markup = '<a class="u-url p-author" href="' . $properties[$type] . '">' . $tweet->user->name . '</a><blockquote class="p-content">' . $tweet->full_text . '</blockquote></div>';
+    } else {
+        # problem getting the tweet; so make a best effort to display something
+        # useful.
+        if ($type == 'in-reply-to') {
+            $prefix = '<div class="u-in-reply-to">Replying to ';
+        }
+        if ($type == 'repost-of') {
+            $prefix = '<div class="u-repost-of">Repost of ';
+            $suffix = '';
+        }
+        $markup = '<a class="u-url" href="' . $properties[$type] . '">' . $properties[$type] . '</a></div>';
+    }
+    $content = $prefix . $markup . $suffix;
+    return [$properties, $content];
+}
+
 function syndicate_twitter($config, $properties, $content, $url) {
     # build our Twitter object
     $t = twitter_init($config['key'], $config['secret'], $config['token'], $config['token_secret']);

--- a/inc/twitter.php
+++ b/inc/twitter.php
@@ -39,24 +39,24 @@ function twitter_reply_or_repost( $type, $properties, $content) {
     if ( false !== $tweet ) {
         $properties["$type-name"] = $tweet->user->name;
         if ($type == 'in-reply-to') {
-            $prefix = '<div class="u-in-reply-to h-cite">Replying to ';
+            $prefix = '<div class="u-in-reply-to h-cite">In reply to ';
         }
         if ($type == 'repost-of') {
             $prefix = '<div class="u-repost-of h-cite">Repost of ';
             $suffix = '';
         }
-        $markup = '<a class="u-url p-author" href="' . $properties[$type] . '">' . $tweet->user->name . '</a><blockquote class="p-content">' . $tweet->full_text . '</blockquote></div>';
+        $markup = '<a class="u-url p-author" href="' . $properties[$type] . '">' . $tweet->user->name . '</a>: <blockquote class="p-content">' . $tweet->full_text . '</blockquote></div>';
     } else {
         # problem getting the tweet; so make a best effort to display something
         # useful.
         if ($type == 'in-reply-to') {
-            $prefix = '<div class="u-in-reply-to">Replying to ';
+            $prefix = '<div class="u-in-reply-to">In reply to ';
         }
         if ($type == 'repost-of') {
             $prefix = '<div class="u-repost-of">Repost of ';
             $suffix = '';
         }
-        $markup = '<a class="u-url" href="' . $properties[$type] . '">' . $properties[$type] . '</a></div>';
+        $markup = '<a class="u-url" href="' . $properties[$type] . '">' . $properties[$type] . '</a>: </div>';
     }
     $content = $prefix . $markup . $suffix;
     return [$properties, $content];


### PR DESCRIPTION
Check the URL of replies and reposts, and support silo-specific functions to handle them.  This allows me to fetch the contents of Tweets for inclusion in the reply.  If there is no silo-specific function, just reference the URL.