### PR TITLE
Support more indieweb post types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,24 @@
+# CHANGELOG
+
+* Thu May 24 2018 Scott Merrill <skippy@skippy.net> - 1.1.0
+- support more indieweb post types than just reposts and replies
+- better timezone handling
+- support configurable token endpoints
+- reposts and replies can interact with their source URLs
+- perform post type discovery
+- use "tweet_mode=extended" to get full tweet text
+- add Twitter silo support
+- handle media uploads more fully
+
+
+* Fri Apr 20 2018 Scott Merrill <skippy@skippy.net> - 1.0.0
+- 1.0 release
+- support most of the Micropub spec
+- tested against micropub.rocks
+- use "name" property as article titles
+
+* Fri Apr 13 2018 Scott Merrill <skippy@skippy.net> - 0.9
+- handle all content and media actions
+
+* Tue Mar 27 2018 Scott Merrill <skippy@skippy.net> - 0.0.1
+- initial commit

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Content you create can be syndicated to external services. Right now, only Twitt
 
 Each syndication target is required to have configuration declared in the `syndication` array in `config.php`.  Then, each syndication target should have a function `syndication_<target>`, where <target> matches the name of the array key in `config.php`.  Each such function is expected to return the URL of the syndicated copy of this post, which will be added to the front matter of the post.
 
-### Replies and Reposts
-Replies and reposts are [silo](https://indieweb.org/silo)-aware.  Right now, the only supported silo is Twitter.  If the source of a reply or repost is a Tweet, the original tweet will be retreived, and stored in the front matter of the post.  Your theme may then elect to use this as needed.  In this way, we can preserve historical context of your activities, and allow you to display referenced data as you need.
+### Source URLs
+Replies, reposts, bookmarks, etc all define a source URL. This server can interact with those sources on a per-target basis.  Right now, the only supported source is Twitter.  If the source of a reply, repost, or bookmark is a Tweet, the original tweet will be retreived, and stored in the front matter of the post.  Your theme may then elect to use this as needed.  In this way, we can preserve historical context of your activities, and allow you to display referenced data as you need.
 
-Additional silos can be added, much like syndication.  To define a new silo, create two new functions that match the format `<silo_domain_name>_in_reply_to` or `<silo_domain_name>_repost_of`.  Convert all dots in the domain name to underscores.  For example, the Twitter silo uses `twitter_com_in_reply_to` and `twitter_com_repost_of`.
+Additional sources can be added, much like syndication.  To define a new source, create a new function that matches the format `<post_type>_<source_domain_name>`.  Convert all dots in the domain name to underscores.  For example, the Twitter source functions use `in_reply_to_twitter_com` and `repost_of_twitter_com` and `bookmark_of_twitter_com`.
 
-The Twitter silo also defines `m_twitter_com_in_reply_to` and `m_twitter_repost_of`, which are simple wrappers to ensure that this functionality works when using mobile-friendly URLs.
+The Twitter source also defines `<post_type>_m_twitter_com`, which are simple wrappers to ensure that this functionality works when using mobile-friendly URLs.
 
 See `inc/twitter.php` for the implementation details.
 

--- a/config.php.sample
+++ b/config.php.sample
@@ -25,8 +25,12 @@ $config = array(
     # different types of content may have different paths.
     # by default, entries are in the root of the /content/ directory, so
     # are not included here.  Notes are in the /note/ directory.
+    # Reposts and replies are **usually** notes, so stick them in /note/, too.
     'content_paths' => array(
-        'note' => 'note/' . date('Y/m/d/'),
+        'note'        => 'note/' . date('Y/m/d/'),
+        'in-reply-to' => 'note/' . date('Y/m/d/'),
+        'repost-of'   => 'note/' . date('Y/m/d/'),
+        'bookmark-of' => 'link/',
     ),
 
     # whether or not to copy uploaded files to the source /static/ directory.

--- a/inc/content.php
+++ b/inc/content.php
@@ -260,7 +260,11 @@ function create($request, $photos = []) {
     $properties['posttype'] = post_type_discovery($properties);
 
     # invoke any silo-specific functions for this post type.
-    list($properties, $content) = silo_post_type_function($properties['posttype'], $properties, $content);
+    # articles, notes, and photos interact with silos through syndication only.
+    # replies, reposts, likes, bookmarks, etc, may interact with silos here.
+    if (! in_array($type, ['article', 'note', 'photo'])) {
+        list($properties, $content) = silo_post_type_function($properties['posttype'], $properties, $content);
+    }
 
     # all items need a date
     if (!isset($properties['date'])) {

--- a/inc/content.php
+++ b/inc/content.php
@@ -115,7 +115,7 @@ function posttype_source_function($posttype, $properties, $content) {
 # https://indieweb.org/post-type-discovery
 # returns the MF2 post type
 function post_type_discovery($properties) {
-  $vocab = array('rsvp',
+    $vocab = array('rsvp',
                  'in-reply-to',
                  'repost-of',
                  'like-of',

--- a/inc/content.php
+++ b/inc/content.php
@@ -227,8 +227,6 @@ function create($request, $photos = []) {
     global $config;
 
     $mf2 = $request->toMf2();
-    # grab the type of this content, less the "h-" prefix
-    $type = substr($mf2['type'][0], 2);
     # make a more normal PHP array from the MF2 JSON array
     $properties = normalize_properties($mf2['properties']);
 
@@ -262,7 +260,7 @@ function create($request, $photos = []) {
     # invoke any silo-specific functions for this post type.
     # articles, notes, and photos interact with silos through syndication only.
     # replies, reposts, likes, bookmarks, etc, may interact with silos here.
-    if (! in_array($type, ['article', 'note', 'photo'])) {
+    if (! in_array($properties['posttype'], ['article', 'note', 'photo'])) {
         list($properties, $content) = silo_post_type_function($properties['posttype'], $properties, $content);
     }
 
@@ -306,9 +304,9 @@ function create($request, $photos = []) {
     $path = $config['source_path'] . 'content/';
     $url = $config['base_url'];
     # does this type of content require a specific path?
-    if (array_key_exists($type, $config['content_paths'])) {
-        $path .= $config['content_paths'][$type];
-        $url .= $config['content_paths'][$type];
+    if (array_key_exists($properties['posttype'], $config['content_paths'])) {
+        $path .= $config['content_paths'][$properties['posttype']];
+        $url .= $config['content_paths'][$properties['posttype']];
     }
     $filename = $path . $properties['slug'] . '.md';
     $url .= $properties['slug'] . '/index.html';

--- a/inc/twitter.php
+++ b/inc/twitter.php
@@ -15,23 +15,29 @@ function build_tweet_url($tweet) {
   return 'https://twitter.com/' . $tweet->user->screen_name . '/status/' . $tweet->id_str;
 }
 
-# Tweets are fully quotable in reply or repost context, so these are
-# all just wrappers around a single function that handles both cases.
-function twitter_com_in_reply_to($properties, $content) {
-    return twitter_reply_or_repost('in-reply-to', $properties, $content);
+# Tweets are fully quotable in most contexts, so these are
+# all just wrappers around a single function that handles these cases.
+function in_reply_to_twitter_com($properties, $content) {
+    return twitter_source('in-reply-to', $properties, $content);
 }
-function twitter_com_repost_of($properties, $content) {
-    return twitter_reply_or_repost('repost-of', $properties, $content);
+function repost_of_twitter_com($properties, $content) {
+    return twitter_source('repost-of', $properties, $content);
 }
-function m_twitter_com_in_reply_to($properties, $content) {
-    return twitter_reply_or_repost('in-reply-to', $properties, $content);
+function bookmark_of_twitter_com($properties, $content) {
+    return twitter_source('bookmark-of', $properties, $content);
 }
-function m_twitter_com_repost_of($properties, $content) {
-    return twitter_reply_or_repost('repost-of', $properties, $content);
+function in_reply_to_m_twitter_com($properties, $content) {
+    return twitter_source('in-reply-to', $properties, $content);
+}
+function repost_of_m_twitter_com($properties, $content) {
+    return twitter_source('repost-of', $properties, $content);
+}
+function bookmark_of_m_twitter_com($properties, $content) {
+    return twitter_source('bookmark-of', $properties, $content);
 }
 
 # replies and reposts have very similar markup, so this builds it.
-function twitter_reply_or_repost( $type, $properties, $content) {
+function twitter_source( $type, $properties, $content) {
     global $config;
     if (!isset($config['syndication']['twitter'])) {
         return [$properties, $content];

--- a/inc/twitter.php
+++ b/inc/twitter.php
@@ -37,7 +37,6 @@ function twitter_reply_or_repost( $type, $properties, $content) {
         return [$properties, $content];
     }
 
-    $properties['posttype'] = $type;
     $tweet = get_tweet($config['syndication']['twitter'], $properties[$type]);
     if ( false !== $tweet ) {
         $properties["$type-name"] = $tweet->user->name;


### PR DESCRIPTION
Apply the logic from [post type
discovery](https://indieweb.org/post-type-discovery) to handle RSVPs,
liks, bookmarks, etc.

This changes the function `reply_or_repost()` into
`silo_post_type_function()`, to handle all the post types with any
source URL.  I assume that **most** of the time we'll be interacting
with silos that have APIs of some sort when making replies, reposts,
likes, etc; but this will allow users to define custom functions for any
domain with which they may be interacting.