### PR TITLE
Allow external media endpoint via config

### DIFF
--- a/config.php.sample
+++ b/config.php.sample
@@ -36,6 +36,9 @@ $config = array(
     # whether or not to copy uploaded files to the source /static/ directory.
     'copy_uploads_to_source' => true,
 
+    # an external micropub media endpoint to use.
+    # 'media_endpoint' => 'https://example.com/my-media-endpoint/',
+
     # an array of syndication targets; each of which should contain the
     # necessary credentials.
     'syndication' => array(

--- a/inc/common.php
+++ b/inc/common.php
@@ -117,7 +117,10 @@ function show_config($show = 'all') {
         }
     }
 
-    $conf = array("media-endpoint" => $config['base_url'] . 'micropub/index.php');
+    $media_endpoint = isset($config['media_endpoint']) ?
+	$config['media_endpoint'] :
+	($config['base_url'] . 'micropub/index.php');
+    $conf = array("media-endpoint" => $media_endpoint);
     if ( ! empty($syndicate_to) ) {
         $conf['syndicate-to'] = $syndicate_to;
     }


### PR DESCRIPTION
Optionally specify an external micropub media endpoint in config.php to have it show up in the `q=config` query.