### PR TITLE
Allow default syndication targets

### DIFF
--- a/config.php.sample
+++ b/config.php.sample
@@ -47,6 +47,14 @@ $config = array(
                      ),
     ),
 
+    # some Micropub clients don't set syndication targets for some actions,
+    # but we may want to syndicate some stuff all the time.  For each post
+    # kind, define an array of mandatory syndication targets.
+    'always_syndicate' => array(
+        'repost-of'   => array( 'twitter' ),
+        'in-reply-to' => array( 'twitter' ),
+    ),
+
     # the IndieAuth token endpoint to use
     'token_endpoint' => 'https://tokens.indieauth.com/token',
 

--- a/inc/content.php
+++ b/inc/content.php
@@ -318,20 +318,23 @@ function create($request, $photos = []) {
     header('Location: ' . $url);
 
     # syndicate this post
+    $syndication_targets = array();
     # some post kinds may enforce syndication, even if the Micropub client
     # did not send an mp-syndicate-to parameter. This code finds those post
     # kinds and sets the mp-syndicate-to.
     if (isset($config['always_syndicate'])) {
         if (array_key_exists($properties['posttype'], $config['always_syndicate'])) {
             foreach ($config['always_syndicate'][$properties['posttype']] as $target) {
-                $request->commands['mp-syndicate-to'][] = $target;
+                $syndication_targets[] = $target;
             }
         }
     }
     if (isset($request->commands['mp-syndicate-to'])) {
+        $syndication_targets = array_unique(array_merge($syndication_targets, $request->commands['mp-syndicate-to']));
+    }
+    if (! empty($syndication_targets)) {
         # ensure we don't have duplicate syndication targets
-        $request->commands['mp-syndicate-to'] = array_unique($request->commands['mp-syndicate-to']);
-        foreach ($request->commands['mp-syndicate-to'] as $target) {
+        foreach ($syndication_targets as $target) {
             if (function_exists("syndicate_$target")) {
                 $syndicated_url = call_user_func("syndicate_$target", $config['syndication'][$target], $properties, $content, $url);
                 if (false !== $syndicated_url) {

--- a/inc/debug.php
+++ b/inc/debug.php
@@ -6,13 +6,12 @@
 
 function syndicate_debug($config, $properties, $content, $url) {
 
-    $debug_path = $config['base_path'] . 'public/' . $config['syndication']['debug']['path'];
-    if ( ! file_exists($debug_path)) {
-        if ( FALSE === mkdir($debug_path, 0777, true) ) {
-            quit(400, 'cannot_mkdir', 'The content directory could not be created.');
+    if ( ! file_exists($config['path'])) {
+        if ( FALSE === mkdir($config['path'], 0777, true) ) {
+            quit(400, 'cannot_mkdir', 'The debug directory could not be created.');
         }
     }
-    $fileanme = date('YmdHi') . '.txt';
+    $filename = date('YmdHi') . '.txt';
 
     $data = "-----DEBUG OUTPUT-----\n";
     $data .= var_export($properties, true);
@@ -21,8 +20,8 @@ function syndicate_debug($config, $properties, $content, $url) {
     $data .= "\n----------\n";
     $data .= $url;
 
-    if ( FALSE === file_put_contents( $debug_path . $filename, $data ) ) {
+    if ( FALSE === file_put_contents( $config['path'] . $filename, $data ) ) {
         quit(400, 'file_error', 'Unable to open debug file');
     }
-    return $config['base_url'] . $config['syndication']['debug']['path'] . $filename;
+    return $config['url'] . $filename;
 }

--- a/inc/debug.php
+++ b/inc/debug.php
@@ -1,0 +1,28 @@
+<?php
+
+# this syndication target is for testing and debug purposes.
+# it will simply create a file in the specified directory with the
+# values of the post that is being syndicated.
+
+function syndicate_debug($config, $properties, $content, $url) {
+
+    $debug_path = $config['base_path'] . 'public/' . $config['syndication']['debug']['path'];
+    if ( ! file_exists($debug_path)) {
+        if ( FALSE === mkdir($debug_path, 0777, true) ) {
+            quit(400, 'cannot_mkdir', 'The content directory could not be created.');
+        }
+    }
+    $fileanme = date('YmdHi') . '.txt';
+
+    $data = "-----DEBUG OUTPUT-----\n";
+    $data .= var_export($properties, true);
+    $data .= "\n----------\n";
+    $data .= var_export($content, true);
+    $data .= "\n----------\n";
+    $data .= $url;
+
+    if ( FALSE === file_put_contents( $debug_path . $filename, $data ) ) {
+        quit(400, 'file_error', 'Unable to open debug file');
+    }
+    return $config['base_url'] . $config['syndication']['debug']['path'] . $filename;
+}

--- a/inc/twitter.php
+++ b/inc/twitter.php
@@ -60,6 +60,12 @@ function syndicate_twitter($config, $properties, $content, $url) {
     # if this is a repost, we just perform the retweet and collect the
     # URL of our instance of it.
     if (isset($properties['repost-of'])) {
+        # we can only retweet things that originated at Twitter, so
+        # confirm that the URL we're reposting is a Twitter URL.
+        $host = parse_url($properties['repost-of'], PHP_URL_HOST);
+        if (! in_array($host, ['mobile.twitter.com','twitter.com','www.twitter.com','twtr.io'])) {
+            return false;
+        }
         $id = get_tweet_id($properties['repost-of']);
         $tweet = $t->post("statuses/retweet/$id");
         if ($t->getLastHttpCode() != 200) {
@@ -72,6 +78,11 @@ function syndicate_twitter($config, $properties, $content, $url) {
     $params = [] ;
 
     if (isset($properties['in-reply-to'])) {
+        $host = parse_url($properties['in-reply-to'], PHP_URL_HOST);
+        if (! in_array($host, ['mobile.twitter.com','twitter.com','www.twitter.com','twtr.io'])) {
+            # we can't currently syndicate replies to non-Twitter sources.
+            return false;
+        }
         # replies need an ID to which they are replying.
         $params['in_reply_to_status_id'] = get_tweet_id($properties['in-reply-to']);
         $params['auto_populate_reply_metadata'] = true;

--- a/index.php
+++ b/index.php
@@ -14,6 +14,7 @@ include_once './inc/common.php';
 include_once './inc/content.php';
 include_once './inc/media.php';
 include_once './inc/twitter.php';
+include_once './inc/debug.php';
 
 $photo_urls = array();
 

--- a/index.php
+++ b/index.php
@@ -14,7 +14,6 @@ include_once './inc/common.php';
 include_once './inc/content.php';
 include_once './inc/media.php';
 include_once './inc/twitter.php';
-include_once './inc/debug.php';
 
 $photo_urls = array();
 


### PR DESCRIPTION
Some Micropub clients don't present a syndication option for all operations.  Quill and Monocle, for example, don't allow you to syndicate reposts.

I almost always want to syndicate to Twitter, so this PR adds an `always_syndicate` option to the config file.  This defines an array of post kinds, and mandatory syndication targets for each.  In this way, a repost from Quill or Monocle will always trigger a Twitter syndication.

Additionally, this PR restricts Twitter syndication of reposts and replies to only those URLs that originate at Twitter.  This Micropub server is not currently fetching content from arbitrary sources, so it can't currently include that content in a repost.  But for content originating at Twitter, it can use the Twitter API to perform replies and reposts.

Finally, a `debug.php` file is included which allows for syndication debugging.  This file is not sourced by `index.php`, so it will need to manually enabled before it can actually be used.